### PR TITLE
fix: landing particles + start player position

### DIFF
--- a/assets/background-elements-redux-fix/cloudLayer1.png.import
+++ b/assets/background-elements-redux-fix/cloudLayer1.png.import
@@ -3,16 +3,16 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://d4falbcbkv30r"
-path.bptc="res://.godot/imported/cloudLayer1.png-d092160910eded237ab84e6a7f4c5ec7.bptc.ctex"
+path.astc="res://.godot/imported/cloudLayer1.png-d092160910eded237ab84e6a7f4c5ec7.astc.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
+"imported_formats": ["etc2_astc"],
 "vram_texture": true
 }
 
 [deps]
 
 source_file="res://assets/background-elements-redux-fix/cloudLayer1.png"
-dest_files=["res://.godot/imported/cloudLayer1.png-d092160910eded237ab84e6a7f4c5ec7.bptc.ctex"]
+dest_files=["res://.godot/imported/cloudLayer1.png-d092160910eded237ab84e6a7f4c5ec7.astc.ctex"]
 
 [params]
 

--- a/assets/godot-robot/3DGodotRobot_GodotPalette.png.import
+++ b/assets/godot-robot/3DGodotRobot_GodotPalette.png.import
@@ -3,9 +3,9 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://d3a8nx056gruw"
-path.s3tc="res://.godot/imported/3DGodotRobot_GodotPalette.png-5c17cec414783acb4a90efac3699786d.s3tc.ctex"
+path.etc2="res://.godot/imported/3DGodotRobot_GodotPalette.png-5c17cec414783acb4a90efac3699786d.etc2.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
+"imported_formats": ["etc2_astc"],
 "vram_texture": true
 }
 generator_parameters={}
@@ -13,7 +13,7 @@ generator_parameters={}
 [deps]
 
 source_file="res://assets/godot-robot/3DGodotRobot_GodotPalette.png"
-dest_files=["res://.godot/imported/3DGodotRobot_GodotPalette.png-5c17cec414783acb4a90efac3699786d.s3tc.ctex"]
+dest_files=["res://.godot/imported/3DGodotRobot_GodotPalette.png-5c17cec414783acb4a90efac3699786d.etc2.ctex"]
 
 [params]
 

--- a/assets/particles/smoke_07.png.import
+++ b/assets/particles/smoke_07.png.import
@@ -3,16 +3,16 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://hdeulb0io36i"
-path.s3tc="res://.godot/imported/smoke_07.png-5c789664a6c8223ffff191bbb2e3d132.s3tc.ctex"
+path.etc2="res://.godot/imported/smoke_07.png-5c789664a6c8223ffff191bbb2e3d132.etc2.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
+"imported_formats": ["etc2_astc"],
 "vram_texture": true
 }
 
 [deps]
 
 source_file="res://assets/particles/smoke_07.png"
-dest_files=["res://.godot/imported/smoke_07.png-5c789664a6c8223ffff191bbb2e3d132.s3tc.ctex"]
+dest_files=["res://.godot/imported/smoke_07.png-5c789664a6c8223ffff191bbb2e3d132.etc2.ctex"]
 
 [params]
 

--- a/assets/particles/smoke_07_whiter.png.import
+++ b/assets/particles/smoke_07_whiter.png.import
@@ -3,16 +3,16 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://cpup0sskr7u1n"
-path.s3tc="res://.godot/imported/smoke_07_whiter.png-82828c905e79816221198e19311409e4.s3tc.ctex"
+path.etc2="res://.godot/imported/smoke_07_whiter.png-82828c905e79816221198e19311409e4.etc2.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
+"imported_formats": ["etc2_astc"],
 "vram_texture": true
 }
 
 [deps]
 
 source_file="res://assets/particles/smoke_07_whiter.png"
-dest_files=["res://.godot/imported/smoke_07_whiter.png-82828c905e79816221198e19311409e4.s3tc.ctex"]
+dest_files=["res://.godot/imported/smoke_07_whiter.png-82828c905e79816221198e19311409e4.etc2.ctex"]
 
 [params]
 

--- a/assets/particles/star_06.png.import
+++ b/assets/particles/star_06.png.import
@@ -3,16 +3,16 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://cs02pn4bpvkbn"
-path.s3tc="res://.godot/imported/star_06.png-1b7b009cfdbc02c547d216fef79cddac.s3tc.ctex"
+path.etc2="res://.godot/imported/star_06.png-1b7b009cfdbc02c547d216fef79cddac.etc2.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
+"imported_formats": ["etc2_astc"],
 "vram_texture": true
 }
 
 [deps]
 
 source_file="res://assets/particles/star_06.png"
-dest_files=["res://.godot/imported/star_06.png-1b7b009cfdbc02c547d216fef79cddac.s3tc.ctex"]
+dest_files=["res://.godot/imported/star_06.png-1b7b009cfdbc02c547d216fef79cddac.etc2.ctex"]
 
 [params]
 

--- a/assets/particles/star_09.png.import
+++ b/assets/particles/star_09.png.import
@@ -3,16 +3,16 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://pf05fko7oskh"
-path.s3tc="res://.godot/imported/star_09.png-897fbd3f05bc97a5834bbdb2046cf278.s3tc.ctex"
+path.etc2="res://.godot/imported/star_09.png-897fbd3f05bc97a5834bbdb2046cf278.etc2.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
+"imported_formats": ["etc2_astc"],
 "vram_texture": true
 }
 
 [deps]
 
 source_file="res://assets/particles/star_09.png"
-dest_files=["res://.godot/imported/star_09.png-897fbd3f05bc97a5834bbdb2046cf278.s3tc.ctex"]
+dest_files=["res://.godot/imported/star_09.png-897fbd3f05bc97a5834bbdb2046cf278.etc2.ctex"]
 
 [params]
 

--- a/objects/player/particles/jump_land_particles.gd
+++ b/objects/player/particles/jump_land_particles.gd
@@ -5,10 +5,8 @@ extends CPUParticles3D
 var was_jumping = false
 
 func _physics_process(delta):
-	if player.velocity.y < 0:
+	if player.velocity.y < -1:
 		was_jumping = true
 	if was_jumping and player.velocity.y == 0:
 		restart() # deletes the old particle and start a new one
 		was_jumping = false
-	else:
-		emitting = false

--- a/objects/player/player.tscn
+++ b/objects/player/player.tscn
@@ -79,8 +79,8 @@ one_shot = true
 
 [node name="JumpLandParticles" parent="." instance=ExtResource("6_raifw")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.1, 0.4)
-visible = false
 emitting = false
+one_shot = true
 explosiveness = 0.95
 randomness = 0.25
 lifetime_randomness = 0.25

--- a/scenes/game/game.tscn
+++ b/scenes/game/game.tscn
@@ -138,7 +138,6 @@ environment = ExtResource("2_jklnn")
 camera_attributes = SubResource("CameraAttributesPractical_vqa5a")
 
 [node name="Player" parent="." instance=ExtResource("3_jgxyp")]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0)
 MAX_FALL_VELOCITY = 17.0
 
 [node name="ResetBehaviour" parent="Player" instance=ExtResource("4_xvweo")]


### PR DESCRIPTION
I tried to fix the landing particles #2 plus a slight improvement to avoid the particles playing at the start of the level.

Edited the script jump_land_particles.gd:

```diff
var was_jumping = false

func _physics_process(delta):
-	if player.velocity.y < 0:
+	if player.velocity.y < -1:
		was_jumping = true
	if was_jumping and player.velocity.y == 0:
		restart() # deletes the old particle and start a new one
		was_jumping = false
-	else:
-		emitting = false
```

About the `jump_land_particles.tscn` node, I changed the `visible` and the `one_shot` property to `true`. 
Then, I also changed the Y player position to 0 in the game level.