### PR TITLE
feature: add moving block + edit level1 scene

### DIFF
--- a/objects/levels/Level1.tscn
+++ b/objects/levels/Level1.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=28 format=3 uid="uid://brcgwdt4hj1qp"]
+[gd_scene load_steps=29 format=3 uid="uid://brcgwdt4hj1qp"]
 
 [ext_resource type="Texture2D" uid="uid://d4falbcbkv30r" path="res://assets/background-elements-redux-fix/cloudLayer1.png" id="1_axnhr"]
 [ext_resource type="PackedScene" path="res://objects/levels/blocks/block.tscn" id="1_q7ec2"]
@@ -10,6 +10,7 @@
 [ext_resource type="AudioStream" uid="uid://jqgefx8iuipg" path="res://assets/audio/airplane.mp3" id="5_1gatr"]
 [ext_resource type="PackedScene" path="res://objects/flag/flag.tscn" id="5_r025i"]
 [ext_resource type="Texture2D" uid="uid://cpup0sskr7u1n" path="res://assets/particles/smoke_07_whiter.png" id="7_5xlsj"]
+[ext_resource type="PackedScene" uid="uid://b52nwn0wddlj8" path="res://objects/levels/blocks/moving_block.tscn" id="9_jlhk4"]
 [ext_resource type="PackedScene" uid="uid://cjx202wb2knm5" path="res://objects/levels/level1/gpu_particles_3d.tscn" id="11_6qrb8"]
 
 [sub_resource type="Shader" id="Shader_5hboo"]
@@ -359,6 +360,9 @@ libraries = {
 "": SubResource("AnimationLibrary_u7jd8")
 }
 
+[node name="moving_block" parent="DynamicProps" instance=ExtResource("9_jlhk4")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 16, 5, 0)
+
 [node name="Items" type="Node3D" parent="."]
 metadata/_edit_lock_ = true
 
@@ -382,6 +386,12 @@ transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 8, 6.5, 0)
 
 [node name="coinGold4" parent="Coins" instance=ExtResource("4_0qum5")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 13, 6.5, 0)
+
+[node name="coinGold6" parent="Coins" instance=ExtResource("4_0qum5")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 16, 10.5, 0)
+
+[node name="coinGold13" parent="Coins" instance=ExtResource("4_0qum5")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 16, 11.5, 0)
 
 [node name="coinGold5" parent="Coins" instance=ExtResource("4_0qum5")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 18, 3, 0)

--- a/objects/levels/blocks/moving_block.gd
+++ b/objects/levels/blocks/moving_block.gd
@@ -1,0 +1,14 @@
+extends Node3D
+
+@onready var path_follow = $Path3D/PathFollow3D
+@export var speed = 0.2
+
+func _ready():
+	pass
+
+
+func _process(delta):
+	if path_follow.get_progress_ratio() > 1.0 or path_follow.get_progress_ratio() < 0.0:
+		speed = -speed
+
+	path_follow.progress_ratio += speed * delta

--- a/objects/levels/blocks/moving_block.tscn
+++ b/objects/levels/blocks/moving_block.tscn
@@ -1,0 +1,25 @@
+[gd_scene load_steps=4 format=3 uid="uid://b52nwn0wddlj8"]
+
+[ext_resource type="Script" path="res://objects/levels/blocks/moving_block.gd" id="1_gu83f"]
+[ext_resource type="PackedScene" path="res://objects/levels/blocks/block_long.tscn" id="2_6c0yf"]
+
+[sub_resource type="Curve3D" id="Curve3D_4a32x"]
+_data = {
+"points": PackedVector3Array(0, 0, 0, 0, 0, 0, 2.08165e-12, 3, 2.08165e-12, 0, 0, 0, 0, 0, 0, 0, 0, 0),
+"tilts": PackedFloat32Array(0, 0)
+}
+point_count = 2
+
+[node name="moving_block" type="Node3D"]
+script = ExtResource("1_gu83f")
+
+[node name="Path3D" type="Path3D" parent="."]
+curve = SubResource("Curve3D_4a32x")
+
+[node name="PathFollow3D" type="PathFollow3D" parent="Path3D"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 2.08165e-12, 3, 2.08165e-12)
+rotation_mode = 0
+loop = false
+
+[node name="blockLong" parent="Path3D/PathFollow3D" instance=ExtResource("2_6c0yf")]
+transform = Transform3D(-4.37114e-08, 0, 1, 0, 0.5, 0, -1, 0, -4.37114e-08, 0, 0, 0)


### PR DESCRIPTION
# Feature: Moving Platforms #2 

I tried to add a new moving block.
This block moves through a Path3D back and forth in a loop.

<br />

https://user-images.githubusercontent.com/29650993/224952609-6c15c408-c034-4675-8ff2-79abfacfb1df.mp4

<br />

I have created a new scene for the moving_block, and the script attached to it:

```gdscript
extends Node3D

@onready var path_follow = $Path3D/PathFollow3D
@export var speed = 0.2

func _ready():
	pass


func _process(delta):
	if path_follow.get_progress_ratio() > 1.0 or path_follow.get_progress_ratio() < 0.0:
		speed = -speed

	path_follow.progress_ratio += speed * delta
```

Probably there are best practices for moving an object through a PathFollow3D, but for what it needs to do I thought the solution could be ok.

I put the `moving_block` inside the DynamicProps in the level scene, since this object is not static.

![Screenshot 2023-03-14 at 10 25 10](https://user-images.githubusercontent.com/29650993/224956148-2a41424b-e346-4535-8801-3a5f57af1075.png)

I also added two more coins in the level scene as you can see in the video above.