### PR TITLE
feature: jump input buffering

### DIFF
--- a/objects/player/player.gd
+++ b/objects/player/player.gd
@@ -18,7 +18,9 @@ const COYOTE_FRAMES = 10
 var coyote_frames: int = COYOTE_FRAMES
 var jumped = false
 var falling = false
-
+var falling_and_jumped = false
+var input_buffer_frames = 0
+const MAX_INPUT_BUFFER_FRAMES: int = 5
 
 func _physics_process(delta):
 	var direction = _get_direction()
@@ -34,6 +36,7 @@ func _physics_process(delta):
 
 func handle_movement(direction, delta):
 	falling = !is_on_floor() and !jumped
+	falling_and_jumped = !is_on_floor() and jumped
 	# vertical
 	if not is_on_floor():
 		if Input.is_action_pressed("ui_accept"):
@@ -44,13 +47,18 @@ func handle_movement(direction, delta):
 			velocity.y = -min(abs(velocity.y), abs(MAX_FALL_VELOCITY))
 			if falling:
 				coyote_frames -= 1
+			if falling_and_jumped:
+				input_buffer_frames -= 1
 	else:
 		jumped = false
 		coyote_frames = COYOTE_FRAMES
-	if Input.is_action_just_pressed("ui_accept") and (is_on_floor() or (falling and coyote_frames > 0)):
+	if Input.is_action_just_pressed("ui_accept") and (is_on_floor() or (falling and coyote_frames > 0)) or (is_on_floor() and input_buffer_frames > 0):
 		velocity.y = JUMP_VELOCITY
 		$Sfx/JumpSfx.play()
 		jumped = true
+		input_buffer_frames = 0
+	if Input.is_action_just_pressed("ui_accept") and falling_and_jumped:
+		input_buffer_frames = MAX_INPUT_BUFFER_FRAMES
 	# horizontal
 	if direction:
 		speed = lerp(speed, SPEED, delta * 15.)

--- a/objects/player/player.gd
+++ b/objects/player/player.gd
@@ -36,7 +36,7 @@ func _physics_process(delta):
 
 func handle_movement(direction, delta):
 	falling = !is_on_floor() and !jumped
-	falling_and_jumped = !is_on_floor() and jumped
+	falling_and_jumped = !is_on_floor() and jumped and velocity.y <= 0
 	# vertical
 	if not is_on_floor():
 		if Input.is_action_pressed("ui_accept"):
@@ -52,12 +52,15 @@ func handle_movement(direction, delta):
 	else:
 		jumped = false
 		coyote_frames = COYOTE_FRAMES
-	if Input.is_action_just_pressed("ui_accept") and (is_on_floor() or (falling and coyote_frames > 0)) or (is_on_floor() and input_buffer_frames > 0):
+
+	var can_jump = is_on_floor() or (falling and coyote_frames > 0)
+	var jump_requested = Input.is_action_just_pressed("ui_accept") or input_buffer_frames > 0
+	if jump_requested and can_jump:
 		velocity.y = JUMP_VELOCITY
 		$Sfx/JumpSfx.play()
 		jumped = true
 		input_buffer_frames = 0
-	if Input.is_action_just_pressed("ui_accept") and falling_and_jumped:
+	if Input.is_action_just_pressed("ui_accept") and !is_on_floor():
 		input_buffer_frames = MAX_INPUT_BUFFER_FRAMES
 	# horizontal
 	if direction:


### PR DESCRIPTION
# Improvement: Jump input buffering #2 

Here is my first (ever) implementation of the input buffering mechanic.
Now the player can press the jump button right before hitting the floor, and be able to jump when the floor is hit.

The idea is that whenever the player hit the jump button when is in the air (`jumped === true && !is_on_floor`) then `input_buffer_frames` is set to `MAX_INPUT_BUFFER_FRAMES` and starts counting to zero. At this point, if the player hit the floor and `input_buffer_frames > 0` the player jumps automatically.

I haven't set the `MAX_INPUT_BUFFER_FRAMES` the same as `COYOTE_FRAMES` because in this case, 10 frames looked too much to me.

I would appreciate some feedback on this code since is the first time I implement a mechanic like this, probably there is room for improvement.