### PR TITLE
Create game state to track score

### DIFF
--- a/autoloads/game_state.gd
+++ b/autoloads/game_state.gd
@@ -1,0 +1,30 @@
+extends Node
+
+
+var _current_coin_count: int = 0
+var _total_coin_count: int = 0
+
+
+signal state_updated
+
+
+func add_coin_to_count(quantity: int = 1):
+	_total_coin_count += quantity
+
+
+func current_coin_amount():
+	return _current_coin_count
+
+
+func player_got_coin():
+	_current_coin_count += 1
+	emit_signal("state_updated")
+
+
+func reset_state():
+	_current_coin_count = 0
+	_total_coin_count = 0
+
+
+func total_coin_amount():
+	return _total_coin_count

--- a/objects/behaviours/reset_behaviour.gd
+++ b/objects/behaviours/reset_behaviour.gd
@@ -13,4 +13,5 @@ func _process(delta):
 		if !$GameoverSfx.playing:
 			$GameoverSfx.play()
 			await $GameoverSfx.finished
+			GameState.reset_state()
 			get_tree().reload_current_scene()

--- a/objects/coins/coin_gold.gd
+++ b/objects/coins/coin_gold.gd
@@ -2,11 +2,15 @@ extends Node3D
 class_name Coin
 
 
+func _ready():
+	GameState.add_coin_to_count()
+
 func take():
 	$coinGold2.hide()
 	$Area3D.queue_free()
 	$GPUParticles3D.emitting = true
 	$GPUParticles3D.one_shot = true
+	GameState.player_got_coin()
 	await get_tree().create_timer(1).timeout
 	queue_free()
 

--- a/objects/levels/blocks/crate_item.gd
+++ b/objects/levels/blocks/crate_item.gd
@@ -6,7 +6,6 @@ enum CRATE_TYPE {
 	COIN
 }
 
-signal coin_collected
 
 @export var crate_type: CRATE_TYPE = CRATE_TYPE.BASE
 @onready var coin: Node3D = $coinGold
@@ -14,6 +13,7 @@ signal coin_collected
 
 func _ready():
 	if crate_type == CRATE_TYPE.COIN:
+		GameState.add_coin_to_count(2)
 		set_meta('coins', 2)
 	else:
 		$coinGold.queue_free()
@@ -28,7 +28,7 @@ func hit():
 		CRATE_TYPE.COIN:
 			$coinGold/AnimationPlayer.stop()
 			$coinGold/AnimationPlayer.play("appear")
-			emit_signal("coin_collected")
+			GameState.player_got_coin()
 
 			if get_meta('coins') > 1:
 				set_meta('coins', get_meta('coins') - 1)

--- a/objects/levels/blocks/crate_item.tscn
+++ b/objects/levels/blocks/crate_item.tscn
@@ -180,6 +180,7 @@ _data = {
 
 [node name="Crate" type="StaticBody3D" groups=["crates"]]
 script = ExtResource("2_nyaxg")
+crate_type = null
 metadata/type = "crate"
 
 [node name="crateItem" parent="." instance=ExtResource("2_sjado")]

--- a/objects/player/coin_area.gd
+++ b/objects/player/coin_area.gd
@@ -1,6 +1,5 @@
 extends Area3D
 
-signal coin_collected
 
 func _on_area_entered(area):
 	if area and area.get_parent() is Coin:
@@ -10,4 +9,3 @@ func _on_area_entered(area):
 
 func on_coin_overlap(coin: Coin):
 	coin.take()
-	emit_signal("coin_collected")

--- a/project.godot
+++ b/project.godot
@@ -18,6 +18,7 @@ config/icon="res://icon.png"
 [autoload]
 
 Audio="*res://autoloads/Audio.tscn"
+GameState="*res://autoloads/game_state.gd"
 
 [display]
 
@@ -27,6 +28,34 @@ window/stretch/mode="canvas_items"
 
 [input]
 
+ui_left={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":4194319,"physical_keycode":0,"key_label":0,"unicode":4194319,"echo":false,"script":null)
+, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":13,"pressure":0.0,"pressed":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":65,"key_label":0,"unicode":97,"echo":false,"script":null)
+]
+}
+ui_right={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":4194321,"physical_keycode":0,"key_label":0,"unicode":4194321,"echo":false,"script":null)
+, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":14,"pressure":0.0,"pressed":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":68,"key_label":0,"unicode":100,"echo":false,"script":null)
+]
+}
+ui_up={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":4194320,"physical_keycode":0,"key_label":0,"unicode":4194320,"echo":false,"script":null)
+, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":11,"pressure":0.0,"pressed":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":87,"key_label":0,"unicode":119,"echo":false,"script":null)
+]
+}
+ui_down={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":4194322,"physical_keycode":0,"key_label":0,"unicode":4194322,"echo":false,"script":null)
+, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":12,"pressure":0.0,"pressed":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":83,"key_label":0,"unicode":115,"echo":false,"script":null)
+]
+}
 quit={
 "deadzone": 0.5,
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194305,"key_label":0,"unicode":0,"echo":false,"script":null)

--- a/scenes/game/game.gd
+++ b/scenes/game/game.gd
@@ -5,6 +5,10 @@ extends Node3D
 @onready var ui = $GameplayUI
 
 
+@onready var current_coins_label = %Score/CurrentCoins
+@onready var total_coins_label = %Score/TotalCoins
+
+
 var flag: Node3D
 
 
@@ -13,10 +17,8 @@ func _ready():
 	flag = flags[0]
 	if flag and flag is Flag:
 		flag.connect("level_complete", on_level_completed, CONNECT_ONE_SHOT)
-	player.get_node("CoinArea").connect("coin_collected", _on_coin_collected)
-	for crate in get_tree().get_nodes_in_group("crates"):
-		if crate.has_meta("coins"):
-			crate.connect("coin_collected", _on_coin_collected)
+	GameState.connect("state_updated", _on_coin_collected)
+	total_coins_label.text = "/ " + str(GameState.total_coin_amount())
 
 
 func on_level_completed():
@@ -42,9 +44,9 @@ func on_level_completed():
 
 
 func _on_victory_screen_restart_button_pressed():
+	GameState.reset_state()
 	get_tree().reload_current_scene()
 
 
 func _on_coin_collected():
-	var coins_label = ui.get_node("HBoxContainer/HBoxContainer/CoinsCount")
-	coins_label.text = str(int(coins_label.text) + 1)
+	current_coins_label.text = str(GameState.current_coin_amount())

--- a/scenes/game/game.tscn
+++ b/scenes/game/game.tscn
@@ -189,15 +189,16 @@ layout_mode = 2
 texture = ExtResource("8_d8puv")
 expand_mode = 3
 
-[node name="HBoxContainer" type="HBoxContainer" parent="GameplayUI/HBoxContainer"]
+[node name="Score" type="HBoxContainer" parent="GameplayUI/HBoxContainer"]
+unique_name_in_owner = true
 layout_mode = 2
 
-[node name="CoinsCount" type="Label" parent="GameplayUI/HBoxContainer/HBoxContainer"]
+[node name="CurrentCoins" type="Label" parent="GameplayUI/HBoxContainer/Score"]
 layout_mode = 2
 text = "0"
 label_settings = SubResource("LabelSettings_6d14a")
 
-[node name="Label" type="Label" parent="GameplayUI/HBoxContainer/HBoxContainer"]
+[node name="TotalCoins" type="Label" parent="GameplayUI/HBoxContainer/Score"]
 layout_mode = 2
 text = " / 13"
 label_settings = SubResource("LabelSettings_8pmjv")


### PR DESCRIPTION
# Improvement: Create game state to track score

The game state has fields and methods to track the current and total amount of coins.

When a coin is added to the scene at runtime it calls a method to update the global state. If the player gets the coin it calls another method to increase the score, this method then emits a signal with is connected to the functions that update the ui score.


Closes #6